### PR TITLE
Update to use organization secrets for VPM management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.VPM_MANAGEMENT_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VPM_MANAGEMENT_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       # Get the Package version based on the package.json file


### PR DESCRIPTION
## Summary
- Rename secret references from `GH_APP_ID` / `GH_APP_PRIVATE_KEY` to `VPM_MANAGEMENT_GITHUB_APP_ID` / `VPM_MANAGEMENT_GITHUB_APP_PRIVATE_KEY`
- Enables using Organization-level secrets instead of repository-level secrets

## Required Action
After merging, you can delete the old repository-level secrets (`GH_APP_ID`, `GH_APP_PRIVATE_KEY`).

🤖 Generated with [Claude Code](https://claude.ai/code)