### PR TITLE
Add gradient start/end position controls

### DIFF
--- a/Editor/LocalizationResources.cs
+++ b/Editor/LocalizationResources.cs
@@ -230,7 +230,35 @@ namespace MeshUVMaskGenerator
                     [SupportedLanguage.English] = "Dilation Pixels",
                     [SupportedLanguage.Korean] = "확장 픽셀 수"
                 },
-                
+
+                ["label.enableGradient"] = new Dictionary<SupportedLanguage, string>
+                {
+                    [SupportedLanguage.Japanese] = "グラデーション有効",
+                    [SupportedLanguage.English] = "Enable Gradient",
+                    [SupportedLanguage.Korean] = "그라디언트 활성화"
+                },
+
+                ["label.gradientAngle"] = new Dictionary<SupportedLanguage, string>
+                {
+                    [SupportedLanguage.Japanese] = "グラデーション角度",
+                    [SupportedLanguage.English] = "Gradient Angle",
+                    [SupportedLanguage.Korean] = "그라디언트 각도"
+                },
+
+                ["label.gradientStart"] = new Dictionary<SupportedLanguage, string>
+                {
+                    [SupportedLanguage.Japanese] = "グラデーション開始",
+                    [SupportedLanguage.English] = "Gradient Start",
+                    [SupportedLanguage.Korean] = "그라디언트 시작"
+                },
+
+                ["label.gradientEnd"] = new Dictionary<SupportedLanguage, string>
+                {
+                    [SupportedLanguage.Japanese] = "グラデーション終了",
+                    [SupportedLanguage.English] = "Gradient End",
+                    [SupportedLanguage.Korean] = "그라디언트 끝"
+                },
+
                 ["label.outputChannel"] = new Dictionary<SupportedLanguage, string>
                 {
                     [SupportedLanguage.Japanese] = "出力チャネル",

--- a/Editor/MeshUVMaskGeneratorWindow.cs
+++ b/Editor/MeshUVMaskGeneratorWindow.cs
@@ -220,6 +220,15 @@ namespace MeshUVMaskGenerator
 
             uvMaskGenerator.DilationPixels = EditorGUILayout.IntSlider(LocalizationManager.GetText("label.dilationPixels"), uvMaskGenerator.DilationPixels, 0, 5);
 
+            uvMaskGenerator.EnableGradient = EditorGUILayout.Toggle(LocalizationManager.GetText("label.enableGradient"), uvMaskGenerator.EnableGradient);
+
+            if (uvMaskGenerator.EnableGradient)
+            {
+                uvMaskGenerator.GradientAngle = EditorGUILayout.Slider(LocalizationManager.GetText("label.gradientAngle"), uvMaskGenerator.GradientAngle, 0f, 360f);
+                uvMaskGenerator.GradientStart = EditorGUILayout.Slider(LocalizationManager.GetText("label.gradientStart"), uvMaskGenerator.GradientStart, 0f, 1f);
+                uvMaskGenerator.GradientEnd = EditorGUILayout.Slider(LocalizationManager.GetText("label.gradientEnd"), uvMaskGenerator.GradientEnd, 0f, 1f);
+            }
+
             if (EditorGUI.EndChangeCheck())
             {
                 parametersChanged = true;

--- a/Editor/UVMaskGenerator.cs
+++ b/Editor/UVMaskGenerator.cs
@@ -20,6 +20,10 @@ namespace MeshUVMaskGenerator
         public float LineThickness { get; set; } = 1.0f;
         public int DilationPixels { get; set; } = 0;
         public MaskChannel OutputChannel { get; set; } = MaskChannel.RGBA;
+        public bool EnableGradient { get; set; } = false;
+        public float GradientAngle { get; set; } = 0f;
+        public float GradientStart { get; set; } = 0f;
+        public float GradientEnd { get; set; } = 1f;
 
         public Texture2D GenerateUVMask(Mesh mesh, int[] triangles)
         {
@@ -54,6 +58,11 @@ namespace MeshUVMaskGenerator
             if (DilationPixels > 0)
             {
                 pixels = ApplyDilation(pixels, TextureSize, DilationPixels);
+            }
+
+            if (EnableGradient)
+            {
+                pixels = ApplyGradient(pixels, TextureSize);
             }
 
             texture.SetPixels(pixels);
@@ -256,6 +265,84 @@ namespace MeshUVMaskGenerator
                 else
                 {
                     result[i] = ApplyChannelMask(originalPixels[i], BackgroundColor);
+                }
+            }
+
+            return result;
+        }
+
+        private Color[] ApplyGradient(Color[] pixels, int size)
+        {
+            float rad = GradientAngle * Mathf.Deg2Rad;
+            float dirX = Mathf.Cos(rad);
+            float dirY = Mathf.Sin(rad);
+
+            // Find projection min/max over mask pixels only
+            float projMin = float.MaxValue;
+            float projMax = float.MinValue;
+            bool hasMask = false;
+
+            for (int y = 0; y < size; y++)
+            {
+                for (int x = 0; x < size; x++)
+                {
+                    int index = y * size + x;
+                    if (!IsBackgroundColor(pixels[index]))
+                    {
+                        float proj = x * dirX + y * dirY;
+                        if (proj < projMin) projMin = proj;
+                        if (proj > projMax) projMax = proj;
+                        hasMask = true;
+                    }
+                }
+            }
+
+            if (!hasMask || Mathf.Approximately(projMin, projMax))
+                return pixels;
+
+            float range = projMax - projMin;
+
+            Color[] result = new Color[pixels.Length];
+            Color bgColor = (OutputChannel == MaskChannel.RGBA) ? BackgroundColor : Color.clear;
+
+            for (int y = 0; y < size; y++)
+            {
+                for (int x = 0; x < size; x++)
+                {
+                    int index = y * size + x;
+                    if (IsBackgroundColor(pixels[index]))
+                    {
+                        result[index] = pixels[index];
+                    }
+                    else
+                    {
+                        float proj = x * dirX + y * dirY;
+                        float tRaw = (proj - projMin) / range;
+                        float gradientRange = GradientEnd - GradientStart;
+                        float t = gradientRange > 0f
+                            ? Mathf.Clamp01((tRaw - GradientStart) / gradientRange)
+                            : (tRaw >= GradientEnd ? 1f : 0f);
+
+                        switch (OutputChannel)
+                        {
+                            case MaskChannel.Red:
+                                result[index] = Color.Lerp(Color.clear, new Color(1f, 0f, 0f, 1f), t);
+                                break;
+                            case MaskChannel.Green:
+                                result[index] = Color.Lerp(Color.clear, new Color(0f, 1f, 0f, 1f), t);
+                                break;
+                            case MaskChannel.Blue:
+                                result[index] = Color.Lerp(Color.clear, new Color(0f, 0f, 1f, 1f), t);
+                                break;
+                            case MaskChannel.Alpha:
+                                result[index] = Color.Lerp(Color.clear, new Color(0f, 0f, 0f, 1f), t);
+                                break;
+                            case MaskChannel.RGBA:
+                            default:
+                                result[index] = Color.Lerp(BackgroundColor, MaskColor, t);
+                                break;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- グラデーションの開始位置（0-1）と終了位置（0-1）を指定できるプロパティ `GradientStart` / `GradientEnd` を追加
- マスク領域の一部だけにグラデーションをかけ、範囲外を背景色/マスク色で塗りつぶすことが可能に
- `GradientStart >= GradientEnd` のエッジケースに対する除算ゼロ回避ガードを実装

## Test plan
- [ ] グラデーション有効化後、Start=0, End=1 で従来と同じ結果になることを確認
- [ ] Start=0.3, End=0.7 でグラデーション範囲が中央60%に絞られることを確認
- [ ] Start > End のケースでエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)